### PR TITLE
refactor: jira integration (GDE-82)

### DIFF
--- a/jira/jira_author.py
+++ b/jira/jira_author.py
@@ -1,0 +1,11 @@
+class JiraAuthor:
+	def __init__(self, account_id: str, email_address: str):
+		self.account_id = account_id
+		self.email_address = email_address
+
+	@staticmethod
+	def from_dict(data: dict):
+		return JiraAuthor(
+			account_id=data.get("accountId"),
+			email_address=data.get("emailAddress"),
+		)

--- a/jira/jira_integration/doctype/jira_settings/jira_settings.js
+++ b/jira/jira_integration/doctype/jira_settings/jira_settings.js
@@ -9,7 +9,7 @@ frappe.ui.form.on('Jira Settings', {
 				frappe.call({
 					method: "jira.tasks.daily.sync_work_logs_from_jira",
 					args: {
-						project: frm.doc.name
+						jira_settings_name: frm.doc.name
 					},
 					callback: function (r) {
 						frappe.show_alert({ message: __("Synced"), indicator: 'green' });

--- a/jira/jira_integration/doctype/jira_settings/jira_settings.py
+++ b/jira/jira_integration/doctype/jira_settings/jira_settings.py
@@ -5,4 +5,5 @@
 from frappe.model.document import Document
 
 class JiraSettings(Document):
-	pass
+	def get_user_cost(self) -> "dict[str, float]":
+		return {user.email: user.costing_rate for user in self.billing}

--- a/jira/jira_issue.py
+++ b/jira/jira_issue.py
@@ -1,0 +1,19 @@
+from urllib.parse import urljoin
+
+class JiraIssue:
+	def __init__(self, id: str, key: str, project: str, summary: str, url: str):
+		self.id = id
+		self.key = key
+		self.project = project
+		self.summary = summary
+		self.url = url
+
+	@staticmethod
+	def from_dict(data: dict):
+		return JiraIssue(
+			id=data.get("id"),
+			project=data.get("project"),
+			key=data.get("key"),
+			summary=data.get("fields", {}).get("summary"),
+			url=urljoin(data.get("self"), f"/browse/{data.get('key')}"),
+		)

--- a/jira/jira_worklog.py
+++ b/jira/jira_worklog.py
@@ -1,0 +1,78 @@
+from dateutil.parser import isoparse
+from datetime import datetime
+
+from .jira_author import JiraAuthor
+
+
+class JiraWorklog:
+	def __init__(
+		self,
+		id: str,
+		author: JiraAuthor,
+		from_time: datetime,
+		time_spent_seconds: int,
+		comment: str,
+	):
+		self.id = id
+		self.author = author
+		self.from_time = from_time
+		self.time_spent_seconds = time_spent_seconds
+		self.comment = comment
+
+	@staticmethod
+	def from_dict(data: dict):
+		return JiraWorklog(
+			id=data.get("id"),
+			author=JiraAuthor.from_dict(data.get("author", {})),
+			from_time=isoparse(data.get("started")),
+			time_spent_seconds=data.get("timeSpentSeconds", 0),
+			comment=parse_comments(data.get("comment")),
+		)
+
+
+def parse_comments(comments, list_indent=None):
+	"""
+	The structure of the comment content is as per the Atlassian Document Format (ADF)
+	https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+
+	To extract the text content, the function is run recursively to get the text
+	extracted from the nested dictionary.
+
+	The list structure for bulletList, orderedList is preserved by adding a hyphen
+	to preserve the list structure.
+
+	The structure has a nested dict structure
+	https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/#json-structure
+
+	Parameters:
+	comments (dict, list): This is either the dict of the comment or just the content of the comment structure
+	list_indent (int): This is used to indent the content if the text is a part of bulletList, orderedList and to add hyphen before rendering the text
+
+	Returns:
+	description (string): Parsed text comment from ADF fromat.
+	"""
+	if not comments:
+		return
+
+	if not list_indent:
+		list_indent = 0
+
+	description = ""
+
+	if isinstance(comments, dict):
+		comments = comments.get("content", [])
+
+	for content in comments:
+		if content.get("text"):
+			# if list starts, the list_index will be set to 1, but while rendering, we do not want the indent
+			# to be visible, hence substracting 1 will give us the correct indent while displaying
+			description += f"\n{(list_indent - 1) * '	' if list_indent else ''}{'- ' if list_indent else ''}{content.get('text')}"
+		elif content.get("content"):
+			if content.get("type") in ["bulletList", "orderedList"]:
+				list_indent += 1
+
+			description += parse_comments(content.get("content"), list_indent)
+		else:
+			description += "\n"
+
+	return description

--- a/jira/tasks/daily.py
+++ b/jira/tasks/daily.py
@@ -81,7 +81,10 @@ def sync_work_logs(
 			else:
 				timesheet.append("time_logs", time_log)
 
-			timesheet.save()
+			try:
+				timesheet.save()
+			except frappe.exceptions.ValidationError:
+				frappe.log_error(frappe.get_traceback())
 
 
 def get_timesheet(


### PR DESCRIPTION
We have an issue, that billed timesheets are getting duplicated as draft again. Hence I used this opportunity to understand and refactor this integration:

- Separate classes `JiraIssue`, `JiraWorklog` and `JiraAuthor` that handle parsing the JSON data and provide easy access to the attributes we need
- Refactor `JiraClient` to store auth and headers in a `requests.session`, simplify error handling
- Get rid of the `JiraWorkspace` class - relevant information is passed through the parameters.

Turned out at a couple more lines of code, but hopefully a bit easier to read.